### PR TITLE
Remove auth on GET /users/[userId] route, add avatar integration, store and return per-user game statistics, remove "status" field 

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/UserStatus.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/UserStatus.java
@@ -1,5 +1,0 @@
-package ch.uzh.ifi.hase.soprafs26.constant;
-
-public enum UserStatus {
-	ONLINE, OFFLINE;
-}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
@@ -83,7 +83,7 @@ public class GameController {
 		double distance;
 		int scoreRound;
 
-		if (userGuessObj.getLatitude() == -1.0 && userGuessObj.getLatitude() == -1.0) {
+		if (userGuessObj.getLatitude() == -1.0 && userGuessObj.getLongitude() == -1.0) {
 			distance = -1.0;
 			scoreRound = 0;
 
@@ -97,6 +97,7 @@ public class GameController {
 		gameService.saveCoordinates(userGuessObj.getUserId(), userGuessObj.getSessionId(), userGuessObj.getLatitude(),
 				userGuessObj.getLongitude());
 		gameService.validateSessionGameGuess(userGuessObj.getSessionId(), userGuessObj.getRoundNumber());
+		userService.recordPlayedRound(userGuessObj.getUserId(), distance, scoreRound);
 
 		return DTOMapper.INSTANCE.convertEntityToUserAnswerPutDTO(gameData, distance, scoreRound, scoreOverall,
 				userGuessObj.getLatitude(), userGuessObj.getLongitude());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -48,10 +48,7 @@ public class UserController {
 
 	@GetMapping("/users/{userId}")
 	@ResponseStatus(HttpStatus.OK)
-	public UserProfileGetDTO getUserById(@PathVariable("userId") Long userId,
-			@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
-		String token = this.userService.extractBearerToken(authorizationHeader);
-		this.userService.getAuthenticatedUser(token);
+	public UserProfileGetDTO getUserById(@PathVariable("userId") Long userId) {
 		User user = userService.getUserById(userId);
 		return DTOMapper.INSTANCE.convertEntityToUserProfileGetDTO(user);
 	}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -88,6 +88,7 @@ public class UserController {
 			@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
 			@RequestBody UserUpdatePutDTO userUpdatePutDTO) {
 		String token = this.userService.extractBearerToken(authorizationHeader);
-		userService.updateUser(userId, token, userUpdatePutDTO.getBio(), userUpdatePutDTO.getNewPassword());
+		userService.updateUser(userId, token, userUpdatePutDTO.getBio(), userUpdatePutDTO.getNewPassword(),
+				userUpdatePutDTO.getMascot_id());
 	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -39,6 +39,9 @@ public class User implements Serializable {
 	@Column(nullable = false, unique = true)
 	private String token;
 
+	@Column(nullable = false)
+	private Integer mascotId = 1;
+
 	@CreationTimestamp
 	@Column(nullable = false, updatable = false)
 	private Instant creationDate;
@@ -81,6 +84,14 @@ public class User implements Serializable {
 
 	public void setToken(String token) {
 		this.token = token;
+	}
+
+	public Integer getMascotId() {
+		return mascotId;
+	}
+
+	public void setMascotId(Integer mascotId) {
+		this.mascotId = mascotId;
 	}
 
 	public Instant getCreationDate() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -2,8 +2,6 @@ package ch.uzh.ifi.hase.soprafs26.entity;
 
 import jakarta.persistence.*;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
-
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.io.Serializable;
@@ -40,9 +38,6 @@ public class User implements Serializable {
 
 	@Column(nullable = false, unique = true)
 	private String token;
-
-	@Column(nullable = false)
-	private UserStatus status;
 
 	@CreationTimestamp
 	@Column(nullable = false, updatable = false)
@@ -86,14 +81,6 @@ public class User implements Serializable {
 
 	public void setToken(String token) {
 		this.token = token;
-	}
-
-	public UserStatus getStatus() {
-		return status;
-	}
-
-	public void setStatus(UserStatus status) {
-		this.status = status;
 	}
 
 	public Instant getCreationDate() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -42,6 +42,15 @@ public class User implements Serializable {
 	@Column(nullable = false)
 	private Integer mascotId = 1;
 
+	@Column(nullable = false)
+	private Integer roundsPlayed = 0;
+
+	@Column(nullable = false)
+	private Double avgDistance = 0.0;
+
+	@Column(nullable = false)
+	private Double avgScore = 0.0;
+
 	@CreationTimestamp
 	@Column(nullable = false, updatable = false)
 	private Instant creationDate;
@@ -92,6 +101,30 @@ public class User implements Serializable {
 
 	public void setMascotId(Integer mascotId) {
 		this.mascotId = mascotId;
+	}
+
+	public Integer getRoundsPlayed() {
+		return roundsPlayed;
+	}
+
+	public void setRoundsPlayed(Integer roundsPlayed) {
+		this.roundsPlayed = roundsPlayed;
+	}
+
+	public Double getAvgDistance() {
+		return avgDistance;
+	}
+
+	public void setAvgDistance(Double avgDistance) {
+		this.avgDistance = avgDistance;
+	}
+
+	public Double getAvgScore() {
+		return avgScore;
+	}
+
+	public void setAvgScore(Double avgScore) {
+		this.avgScore = avgScore;
 	}
 
 	public Instant getCreationDate() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameGetDTO.java
@@ -1,7 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
-
 public class GameGetDTO {
 
 	private String sessionId;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
@@ -1,13 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
-
 public class UserGetDTO {
 
 	private Long id;
 	private String username;
 	private String bio;
-	private UserStatus status;
 
 	public Long getId() {
 		return id;
@@ -33,11 +30,4 @@ public class UserGetDTO {
 		this.bio = bio;
 	}
 
-	public UserStatus getStatus() {
-		return status;
-	}
-
-	public void setStatus(UserStatus status) {
-		this.status = status;
-	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
@@ -5,6 +5,7 @@ public class UserGetDTO {
 	private Long id;
 	private String username;
 	private String bio;
+	private Integer mascot_id;
 
 	public Long getId() {
 		return id;
@@ -30,4 +31,11 @@ public class UserGetDTO {
 		this.bio = bio;
 	}
 
+	public Integer getMascot_id() {
+		return mascot_id;
+	}
+
+	public void setMascot_id(Integer mascot_id) {
+		this.mascot_id = mascot_id;
+	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserGetDTO.java
@@ -6,6 +6,9 @@ public class UserGetDTO {
 	private String username;
 	private String bio;
 	private Integer mascot_id;
+	private Integer rounds_played;
+	private Double avg_distance;
+	private Double avg_score;
 
 	public Long getId() {
 		return id;
@@ -37,5 +40,29 @@ public class UserGetDTO {
 
 	public void setMascot_id(Integer mascot_id) {
 		this.mascot_id = mascot_id;
+	}
+
+	public Integer getRounds_played() {
+		return rounds_played;
+	}
+
+	public void setRounds_played(Integer rounds_played) {
+		this.rounds_played = rounds_played;
+	}
+
+	public Double getAvg_distance() {
+		return avg_distance;
+	}
+
+	public void setAvg_distance(Double avg_distance) {
+		this.avg_distance = avg_distance;
+	}
+
+	public Double getAvg_score() {
+		return avg_score;
+	}
+
+	public void setAvg_score(Double avg_score) {
+		this.avg_score = avg_score;
 	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserProfileGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserProfileGetDTO.java
@@ -8,6 +8,9 @@ public class UserProfileGetDTO {
 	private String username;
 	private String bio;
 	private Integer mascot_id;
+	private Integer rounds_played;
+	private Double avg_distance;
+	private Double avg_score;
 	private Instant creationDate;
 
 	public Long getId() {
@@ -40,6 +43,30 @@ public class UserProfileGetDTO {
 
 	public void setMascot_id(Integer mascot_id) {
 		this.mascot_id = mascot_id;
+	}
+
+	public Integer getRounds_played() {
+		return rounds_played;
+	}
+
+	public void setRounds_played(Integer rounds_played) {
+		this.rounds_played = rounds_played;
+	}
+
+	public Double getAvg_distance() {
+		return avg_distance;
+	}
+
+	public void setAvg_distance(Double avg_distance) {
+		this.avg_distance = avg_distance;
+	}
+
+	public Double getAvg_score() {
+		return avg_score;
+	}
+
+	public void setAvg_score(Double avg_score) {
+		this.avg_score = avg_score;
 	}
 
 	public Instant getCreationDate() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserProfileGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserProfileGetDTO.java
@@ -7,6 +7,7 @@ public class UserProfileGetDTO {
 	private Long id;
 	private String username;
 	private String bio;
+	private Integer mascot_id;
 	private Instant creationDate;
 
 	public Long getId() {
@@ -31,6 +32,14 @@ public class UserProfileGetDTO {
 
 	public void setBio(String bio) {
 		this.bio = bio;
+	}
+
+	public Integer getMascot_id() {
+		return mascot_id;
+	}
+
+	public void setMascot_id(Integer mascot_id) {
+		this.mascot_id = mascot_id;
 	}
 
 	public Instant getCreationDate() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserProfileGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserProfileGetDTO.java
@@ -1,7 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
-
 import java.time.Instant;
 
 public class UserProfileGetDTO {
@@ -9,7 +7,6 @@ public class UserProfileGetDTO {
 	private Long id;
 	private String username;
 	private String bio;
-	private UserStatus status;
 	private Instant creationDate;
 
 	public Long getId() {
@@ -34,14 +31,6 @@ public class UserProfileGetDTO {
 
 	public void setBio(String bio) {
 		this.bio = bio;
-	}
-
-	public UserStatus getStatus() {
-		return status;
-	}
-
-	public void setStatus(UserStatus status) {
-		this.status = status;
 	}
 
 	public Instant getCreationDate() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserRegisterResponseDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserRegisterResponseDTO.java
@@ -5,6 +5,7 @@ public class UserRegisterResponseDTO {
 	private Long id;
 	private String username;
 	private String bio;
+	private Integer mascot_id;
 	private String token;
 
 	public Long getId() {
@@ -29,6 +30,14 @@ public class UserRegisterResponseDTO {
 
 	public void setBio(String bio) {
 		this.bio = bio;
+	}
+
+	public Integer getMascot_id() {
+		return mascot_id;
+	}
+
+	public void setMascot_id(Integer mascot_id) {
+		this.mascot_id = mascot_id;
 	}
 
 	public String getToken() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserRegisterResponseDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserRegisterResponseDTO.java
@@ -1,13 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
-
 public class UserRegisterResponseDTO {
 
 	private Long id;
 	private String username;
 	private String bio;
-	private UserStatus status;
 	private String token;
 
 	public Long getId() {
@@ -32,14 +29,6 @@ public class UserRegisterResponseDTO {
 
 	public void setBio(String bio) {
 		this.bio = bio;
-	}
-
-	public UserStatus getStatus() {
-		return status;
-	}
-
-	public void setStatus(UserStatus status) {
-		this.status = status;
 	}
 
 	public String getToken() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserUpdatePutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/UserUpdatePutDTO.java
@@ -6,6 +6,8 @@ public class UserUpdatePutDTO {
 
 	private String newPassword;
 
+	private Integer mascot_id;
+
 	public String getBio() {
 		return bio;
 	}
@@ -20,5 +22,13 @@ public class UserUpdatePutDTO {
 
 	public void setNewPassword(String newPassword) {
 		this.newPassword = newPassword;
+	}
+
+	public Integer getMascot_id() {
+		return mascot_id;
+	}
+
+	public void setMascot_id(Integer mascot_id) {
+		this.mascot_id = mascot_id;
 	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -36,6 +36,7 @@ public interface DTOMapper {
 	@Mapping(target = "id", ignore = true)
 	@Mapping(target = "passwordHash", ignore = true)
 	@Mapping(target = "token", ignore = true)
+	@Mapping(target = "mascotId", ignore = true)
 	@Mapping(target = "creationDate", ignore = true)
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
@@ -44,17 +45,20 @@ public interface DTOMapper {
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
+	@Mapping(source = "mascotId", target = "mascot_id")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
+	@Mapping(source = "mascotId", target = "mascot_id")
 	@Mapping(source = "creationDate", target = "creationDate")
 	UserProfileGetDTO convertEntityToUserProfileGetDTO(User user);
 
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
+	@Mapping(source = "mascotId", target = "mascot_id")
 	@Mapping(source = "token", target = "token")
 	UserRegisterResponseDTO convertEntityToUserRegisterResponseDTO(User user);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -37,6 +37,9 @@ public interface DTOMapper {
 	@Mapping(target = "passwordHash", ignore = true)
 	@Mapping(target = "token", ignore = true)
 	@Mapping(target = "mascotId", ignore = true)
+	@Mapping(target = "roundsPlayed", ignore = true)
+	@Mapping(target = "avgDistance", ignore = true)
+	@Mapping(target = "avgScore", ignore = true)
 	@Mapping(target = "creationDate", ignore = true)
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
@@ -46,12 +49,18 @@ public interface DTOMapper {
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
 	@Mapping(source = "mascotId", target = "mascot_id")
+	@Mapping(source = "roundsPlayed", target = "rounds_played")
+	@Mapping(source = "avgDistance", target = "avg_distance")
+	@Mapping(source = "avgScore", target = "avg_score")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
 	@Mapping(source = "mascotId", target = "mascot_id")
+	@Mapping(source = "roundsPlayed", target = "rounds_played")
+	@Mapping(source = "avgDistance", target = "avg_distance")
+	@Mapping(source = "avgScore", target = "avg_score")
 	@Mapping(source = "creationDate", target = "creationDate")
 	UserProfileGetDTO convertEntityToUserProfileGetDTO(User user);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -36,7 +36,6 @@ public interface DTOMapper {
 	@Mapping(target = "id", ignore = true)
 	@Mapping(target = "passwordHash", ignore = true)
 	@Mapping(target = "token", ignore = true)
-	@Mapping(target = "status", ignore = true)
 	@Mapping(target = "creationDate", ignore = true)
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
@@ -45,20 +44,17 @@ public interface DTOMapper {
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
-	@Mapping(source = "status", target = "status")
 	UserGetDTO convertEntityToUserGetDTO(User user);
 
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
-	@Mapping(source = "status", target = "status")
 	@Mapping(source = "creationDate", target = "creationDate")
 	UserProfileGetDTO convertEntityToUserProfileGetDTO(User user);
 
 	@Mapping(source = "id", target = "id")
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "bio", target = "bio")
-	@Mapping(source = "status", target = "status")
 	@Mapping(source = "token", target = "token")
 	UserRegisterResponseDTO convertEntityToUserRegisterResponseDTO(User user);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 
@@ -66,7 +65,6 @@ public class UserService {
 		checkIfUsernameExists(newUser.getUsername());
 		newUser.setPasswordHash(BCrypt.hashpw(rawPassword, BCrypt.gensalt()));
 		newUser.setToken(UUID.randomUUID().toString());
-		newUser.setStatus(UserStatus.ONLINE);
 		// saves the given entity but data is only persisted in the database once
 		// flush() is called
 		newUser = userRepository.save(newUser);
@@ -86,9 +84,6 @@ public class UserService {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The username or password provided is incorrect.");
 		}
 
-		user.setStatus(UserStatus.ONLINE);
-		userRepository.save(user);
-		userRepository.flush();
 		return user;
 	}
 
@@ -102,7 +97,6 @@ public class UserService {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The provided token is invalid.");
 		}
 
-		user.setStatus(UserStatus.OFFLINE);
 		user.setToken(UUID.randomUUID().toString());
 		userRepository.save(user);
 		userRepository.flush();
@@ -134,7 +128,6 @@ public class UserService {
 
 		if (updatePassword) {
 			targetUser.setPasswordHash(BCrypt.hashpw(newPassword, BCrypt.gensalt()));
-			targetUser.setStatus(UserStatus.OFFLINE);
 			targetUser.setToken(UUID.randomUUID().toString());
 		}
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -28,6 +28,7 @@ public class UserService {
 
 	private static final int MAX_BIO_LENGTH = 280;
 	private static final int MIN_PASSWORD_LENGTH = 8;
+	private static final double NO_GUESS_DISTANCE_KM = 20000.0;
 
 	private final Logger log = LoggerFactory.getLogger(UserService.class);
 
@@ -146,6 +147,23 @@ public class UserService {
 		}
 
 		userRepository.save(targetUser);
+		userRepository.flush();
+	}
+
+	public void recordPlayedRound(Long userId, double distance, int scoreRound) {
+		User user = getUserById(userId);
+
+		int oldRoundsPlayed = user.getRoundsPlayed() != null ? user.getRoundsPlayed() : 0;
+		int newRoundsPlayed = oldRoundsPlayed + 1;
+		double statsDistance = distance < 0 ? NO_GUESS_DISTANCE_KM : distance;
+		double oldAvgDistance = user.getAvgDistance() != null ? user.getAvgDistance() : 0.0;
+		double oldAvgScore = user.getAvgScore() != null ? user.getAvgScore() : 0.0;
+
+		user.setRoundsPlayed(newRoundsPlayed);
+		user.setAvgDistance(((oldAvgDistance * oldRoundsPlayed) + statsDistance) / newRoundsPlayed);
+		user.setAvgScore(((oldAvgScore * oldRoundsPlayed) + scoreRound) / newRoundsPlayed);
+
+		userRepository.save(user);
 		userRepository.flush();
 	}
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -65,6 +65,10 @@ public class UserService {
 		checkIfUsernameExists(newUser.getUsername());
 		newUser.setPasswordHash(BCrypt.hashpw(rawPassword, BCrypt.gensalt()));
 		newUser.setToken(UUID.randomUUID().toString());
+		if (newUser.getMascotId() == null) {
+			newUser.setMascotId(1);
+		}
+		validateMascotId(newUser.getMascotId());
 		// saves the given entity but data is only persisted in the database once
 		// flush() is called
 		newUser = userRepository.save(newUser);
@@ -102,12 +106,14 @@ public class UserService {
 		userRepository.flush();
 	}
 
-	public void updateUser(Long targetUserId, String requesterToken, String newBio, String newPassword) {
+	public void updateUser(Long targetUserId, String requesterToken, String newBio, String newPassword,
+			Integer newMascotId) {
 		User targetUser = getAuthorizedTargetUser(targetUserId, requesterToken);
 
 		boolean updateBio = newBio != null;
 		boolean updatePassword = newPassword != null;
-		if (!updateBio && !updatePassword) {
+		boolean updateMascot = newMascotId != null;
+		if (!updateBio && !updatePassword && !updateMascot) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
 					"At least one updatable field must be provided.");
 		}
@@ -122,6 +128,10 @@ public class UserService {
 			validateNewPassword(newPassword);
 		}
 
+		if (updateMascot) {
+			validateMascotId(newMascotId);
+		}
+
 		if (updateBio) {
 			targetUser.setBio(normalizedBio);
 		}
@@ -129,6 +139,10 @@ public class UserService {
 		if (updatePassword) {
 			targetUser.setPasswordHash(BCrypt.hashpw(newPassword, BCrypt.gensalt()));
 			targetUser.setToken(UUID.randomUUID().toString());
+		}
+
+		if (updateMascot) {
+			targetUser.setMascotId(newMascotId);
 		}
 
 		userRepository.save(targetUser);
@@ -202,6 +216,12 @@ public class UserService {
 
 		if (newPassword.length() < MIN_PASSWORD_LENGTH) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The password must be at least 8 characters long.");
+		}
+	}
+
+	private void validateMascotId(Integer mascotId) {
+		if (mascotId == null || mascotId <= 0) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The mascot id must be a positive integer.");
 		}
 	}
 	

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameControllerTest.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 import ch.uzh.ifi.hase.soprafs26.entity.Game_data;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGuessPutDTO;
 import ch.uzh.ifi.hase.soprafs26.service.GameService;
 import ch.uzh.ifi.hase.soprafs26.service.GuessEvaluationService;
@@ -72,7 +71,6 @@ public class GameControllerTest {
                 user.setBio("Some bio");
                 user.setPasswordHash("123213123");
                 user.setToken("1");
-                user.setStatus(UserStatus.ONLINE);
                 return user;
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameControllerTest.java
@@ -161,6 +161,7 @@ public class GameControllerTest {
 
 		verify(gameService).saveScore(1L, 40, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 		verify(gameService).validateSessionGameGuess("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 1);
+		verify(userService).recordPlayedRound(1L, 100.0, 40);
 	}
 
 	@Test
@@ -233,6 +234,8 @@ public class GameControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.scoreRound", is(0)))
 				.andExpect(jsonPath("$.distance", is(-1.0)));
+
+		verify(userService).recordPlayedRound(1L, -1.0, 0);
         }
         @Test
         void givenMissingGameData_whenGetGameData_thenReturnNotFound() throws Exception {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
@@ -3,7 +3,6 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 import ch.uzh.ifi.hase.soprafs26.service.SessionService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import ch.uzh.ifi.hase.soprafs26.constant.UserSessionRole;
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.entity.SessionUser;
@@ -70,7 +69,6 @@ public class SessionControllerTest {
                 user.setBio("Some bio");
                 user.setPasswordHash("123213123");
                 user.setToken("1");
-                user.setStatus(UserStatus.ONLINE);
                 return user;
         }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserLoginDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
@@ -58,7 +57,6 @@ public class UserControllerTest {
 		user.setId(1L);
 		user.setUsername("testUsername");
 		user.setBio("Short bio");
-		user.setStatus(UserStatus.ONLINE);
 		user.setToken("valid-token");
 		user.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 		return user;
@@ -81,8 +79,7 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$", hasSize(1)))
 				.andExpect(jsonPath("$[0].id", is(1)))
 				.andExpect(jsonPath("$[0].username", is("testUsername")))
-				.andExpect(jsonPath("$[0].bio", is("Short bio")))
-				.andExpect(jsonPath("$[0].status", is(UserStatus.ONLINE.toString())));
+				.andExpect(jsonPath("$[0].bio", is("Short bio")));
 	}
 
 	/**
@@ -109,7 +106,6 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
-				.andExpect(jsonPath("$.status", is(UserStatus.ONLINE.toString())))
 				.andExpect(jsonPath("$.token", is("valid-token")));
 	}
 
@@ -133,7 +129,6 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
-				.andExpect(jsonPath("$.status", is(UserStatus.ONLINE.toString())))
 				.andExpect(jsonPath("$.creationDate", is(user.getCreationDate().toString())));
 	}
 
@@ -171,7 +166,6 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
-				.andExpect(jsonPath("$.status", is(UserStatus.ONLINE.toString())))
 				.andExpect(jsonPath("$.token", is("valid-token")));
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -57,6 +57,7 @@ public class UserControllerTest {
 		user.setId(1L);
 		user.setUsername("testUsername");
 		user.setBio("Short bio");
+		user.setMascotId(3);
 		user.setToken("valid-token");
 		user.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 		return user;
@@ -79,7 +80,8 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$", hasSize(1)))
 				.andExpect(jsonPath("$[0].id", is(1)))
 				.andExpect(jsonPath("$[0].username", is("testUsername")))
-				.andExpect(jsonPath("$[0].bio", is("Short bio")));
+				.andExpect(jsonPath("$[0].bio", is("Short bio")))
+				.andExpect(jsonPath("$[0].mascot_id", is(3)));
 	}
 
 	/**
@@ -106,6 +108,7 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
+				.andExpect(jsonPath("$.mascot_id", is(3)))
 				.andExpect(jsonPath("$.token", is("valid-token")));
 	}
 
@@ -129,6 +132,7 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
+				.andExpect(jsonPath("$.mascot_id", is(3)))
 				.andExpect(jsonPath("$.creationDate", is(user.getCreationDate().toString())));
 	}
 
@@ -166,6 +170,7 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
+				.andExpect(jsonPath("$.mascot_id", is(3)))
 				.andExpect(jsonPath("$.token", is("valid-token")));
 	}
 
@@ -240,7 +245,23 @@ public class UserControllerTest {
 				.content(controllerTestHelper.asJsonString(userUpdatePutDTO)))
 				.andExpect(status().isNoContent());
 
-		verify(userService).updateUser(1L, "valid-token", "Updated bio", null);
+		verify(userService).updateUser(1L, "valid-token", "Updated bio", null, null);
+	}
+
+	@Test
+	public void updateUser_mascotOnly_noContent() throws Exception {
+		UserUpdatePutDTO userUpdatePutDTO = new UserUpdatePutDTO();
+		userUpdatePutDTO.setMascot_id(7);
+
+		when(userService.extractBearerToken(anyString())).thenReturn("valid-token");
+
+		mockMvc.perform(put("/users/{userId}", 1L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("Authorization", "Bearer valid-token")
+				.content(controllerTestHelper.asJsonString(userUpdatePutDTO)))
+				.andExpect(status().isNoContent());
+
+		verify(userService).updateUser(1L, "valid-token", null, null, 7);
 	}
 
 	/** Tests PUT /users/{userId} and verifies an invalid token returns 401. */

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -57,6 +57,9 @@ public class UserControllerTest {
 		user.setUsername("testUsername");
 		user.setBio("Short bio");
 		user.setMascotId(3);
+		user.setRoundsPlayed(4);
+		user.setAvgDistance(1250.5);
+		user.setAvgScore(72.25);
 		user.setToken("valid-token");
 		user.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 		return user;
@@ -80,7 +83,10 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$[0].id", is(1)))
 				.andExpect(jsonPath("$[0].username", is("testUsername")))
 				.andExpect(jsonPath("$[0].bio", is("Short bio")))
-				.andExpect(jsonPath("$[0].mascot_id", is(3)));
+				.andExpect(jsonPath("$[0].mascot_id", is(3)))
+				.andExpect(jsonPath("$[0].rounds_played", is(4)))
+				.andExpect(jsonPath("$[0].avg_distance", is(1250.5)))
+				.andExpect(jsonPath("$[0].avg_score", is(72.25)));
 	}
 
 	/**
@@ -129,6 +135,9 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
 				.andExpect(jsonPath("$.mascot_id", is(3)))
+				.andExpect(jsonPath("$.rounds_played", is(4)))
+				.andExpect(jsonPath("$.avg_distance", is(1250.5)))
+				.andExpect(jsonPath("$.avg_score", is(72.25)))
 				.andExpect(jsonPath("$.creationDate", is(user.getCreationDate().toString())));
 
 		verify(userService, never()).extractBearerToken(anyString());
@@ -148,7 +157,10 @@ public class UserControllerTest {
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
-				.andExpect(jsonPath("$.mascot_id", is(3)));
+				.andExpect(jsonPath("$.mascot_id", is(3)))
+				.andExpect(jsonPath("$.rounds_played", is(4)))
+				.andExpect(jsonPath("$.avg_distance", is(1250.5)))
+				.andExpect(jsonPath("$.avg_score", is(72.25)));
 
 		verify(userService, never()).extractBearerToken(anyString());
 		verify(userService, never()).getAuthenticatedUser(anyString());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpStatus;
@@ -120,32 +119,39 @@ public class UserControllerTest {
 	public void givenUserId_whenGetUser_thenReturnJsonObject() throws Exception {
 		// given
 		User user = sampleUser();
-		when(userService.extractBearerToken(anyString())).thenReturn("valid-token");
-		when(userService.getAuthenticatedUser("valid-token")).thenReturn(sampleUser());
 		given(userService.getUserById(1L)).willReturn(user);
 
 		// when/then
 		mockMvc.perform(get("/users/{userId}", 1L)
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer valid-token"))
+				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id", is(1)))
 				.andExpect(jsonPath("$.username", is("testUsername")))
 				.andExpect(jsonPath("$.bio", is("Short bio")))
 				.andExpect(jsonPath("$.mascot_id", is(3)))
 				.andExpect(jsonPath("$.creationDate", is(user.getCreationDate().toString())));
+
+		verify(userService, never()).extractBearerToken(anyString());
+		verify(userService, never()).getAuthenticatedUser(anyString());
 	}
 
-	/** Tests GET /users/{userId} and verifies a missing Authorization header returns 401. */
+	/** Tests GET /users/{userId} and verifies a missing Authorization header still returns the public profile. */
 	@Test
-	public void givenMissingAuthorization_whenGetUser_thenReturnUnauthorized() throws Exception {
+	public void givenMissingAuthorization_whenGetUser_thenReturnJsonObject() throws Exception {
 		// given
-		when(userService.extractBearerToken(null))
-				.thenThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The provided token is invalid."));
+		User user = sampleUser();
+		given(userService.getUserById(1L)).willReturn(user);
 
 		// when/then
 		mockMvc.perform(get("/users/{userId}", 1L).contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isUnauthorized());
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is(1)))
+				.andExpect(jsonPath("$.username", is("testUsername")))
+				.andExpect(jsonPath("$.bio", is("Short bio")))
+				.andExpect(jsonPath("$.mascot_id", is(3)));
+
+		verify(userService, never()).extractBearerToken(anyString());
+		verify(userService, never()).getAuthenticatedUser(anyString());
 	}
 
 	/**

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/SessionUserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/SessionUserRepositoryIntegrationTest.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
 import ch.uzh.ifi.hase.soprafs26.constant.UserSessionRole;
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.SessionUser;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
@@ -31,7 +30,6 @@ public class SessionUserRepositoryIntegrationTest {
         user.setUsername("firstname@lastname");
         user.setBio("Short bio");
         user.setPasswordHash("$2a$10$M6Q4j0c5xmq5eS7z7hSI6eqWQ2F/N8z6p10tmSMx8nggKQWQqTKe2");
-        user.setStatus(UserStatus.OFFLINE);
         user.setToken("1");
         LocalDateTime currentDateTime = LocalDateTime.of(2026, 1, 1, 8, 30, 00);
         Session session = new Session();
@@ -67,7 +65,6 @@ public class SessionUserRepositoryIntegrationTest {
         user.setUsername("firstname@lastname");
         user.setBio("Short bio");
         user.setPasswordHash("$2a$10$M6Q4j0c5xmq5eS7z7hSI6eqWQ2F/N8z6p10tmSMx8nggKQWQqTKe2");
-        user.setStatus(UserStatus.OFFLINE);
         user.setToken("1");
         LocalDateTime currentDateTime = LocalDateTime.of(2026, 1, 1, 8, 30, 00);
         Session session = new Session();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
@@ -25,6 +25,7 @@ public class UserRepositoryIntegrationTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Short bio");
 		user.setPasswordHash("$2a$10$M6Q4j0c5xmq5eS7z7hSI6eqWQ2F/N8z6p10tmSMx8nggKQWQqTKe2");
+		user.setMascotId(3);
 		user.setToken("1");
 
 		entityManager.persist(user);
@@ -35,6 +36,7 @@ public class UserRepositoryIntegrationTest {
 		assertNotNull(found.getId());
 		assertEquals(found.getUsername(), user.getUsername());
 		assertEquals(found.getBio(), user.getBio());
+		assertEquals(found.getMascotId(), user.getMascotId());
 		assertEquals(found.getToken(), user.getToken());
 	}
 
@@ -44,6 +46,7 @@ public class UserRepositoryIntegrationTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Short bio");
 		user.setPasswordHash("$2a$10$M6Q4j0c5xmq5eS7z7hSI6eqWQ2F/N8z6p10tmSMx8nggKQWQqTKe2");
+		user.setMascotId(4);
 		user.setToken("token-123");
 
 		entityManager.persist(user);
@@ -54,6 +57,7 @@ public class UserRepositoryIntegrationTest {
 		assertNotNull(found.getId());
 		assertEquals(found.getUsername(), user.getUsername());
 		assertEquals(found.getBio(), user.getBio());
+		assertEquals(found.getMascotId(), user.getMascotId());
 		assertEquals(found.getToken(), user.getToken());
 	}
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepositoryIntegrationTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 @DataJpaTest
@@ -26,7 +25,6 @@ public class UserRepositoryIntegrationTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Short bio");
 		user.setPasswordHash("$2a$10$M6Q4j0c5xmq5eS7z7hSI6eqWQ2F/N8z6p10tmSMx8nggKQWQqTKe2");
-		user.setStatus(UserStatus.OFFLINE);
 		user.setToken("1");
 
 		entityManager.persist(user);
@@ -38,7 +36,6 @@ public class UserRepositoryIntegrationTest {
 		assertEquals(found.getUsername(), user.getUsername());
 		assertEquals(found.getBio(), user.getBio());
 		assertEquals(found.getToken(), user.getToken());
-		assertEquals(found.getStatus(), user.getStatus());
 	}
 
 	@Test
@@ -47,7 +44,6 @@ public class UserRepositoryIntegrationTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Short bio");
 		user.setPasswordHash("$2a$10$M6Q4j0c5xmq5eS7z7hSI6eqWQ2F/N8z6p10tmSMx8nggKQWQqTKe2");
-		user.setStatus(UserStatus.OFFLINE);
 		user.setToken("token-123");
 
 		entityManager.persist(user);
@@ -59,6 +55,5 @@ public class UserRepositoryIntegrationTest {
 		assertEquals(found.getUsername(), user.getUsername());
 		assertEquals(found.getBio(), user.getBio());
 		assertEquals(found.getToken(), user.getToken());
-		assertEquals(found.getStatus(), user.getStatus());
 	}
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -52,6 +52,9 @@ public class DTOMapperTest {
 		user.setBio("Hello from bio");
 		user.setToken("1");
 		user.setMascotId(3);
+		user.setRoundsPlayed(4);
+		user.setAvgDistance(1250.5);
+		user.setAvgScore(72.25);
 
 		// MAP -> Create UserGetDTO
 		UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
@@ -61,6 +64,9 @@ public class DTOMapperTest {
 		assertEquals(user.getUsername(), userGetDTO.getUsername());
 		assertEquals(user.getBio(), userGetDTO.getBio());
 		assertEquals(user.getMascotId(), userGetDTO.getMascot_id());
+		assertEquals(user.getRoundsPlayed(), userGetDTO.getRounds_played());
+		assertEquals(user.getAvgDistance(), userGetDTO.getAvg_distance());
+		assertEquals(user.getAvgScore(), userGetDTO.getAvg_score());
 	}
 
 	@Test
@@ -88,6 +94,9 @@ public class DTOMapperTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
 		user.setMascotId(4);
+		user.setRoundsPlayed(3);
+		user.setAvgDistance(2000.0);
+		user.setAvgScore(50.0);
 		user.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 
 		UserProfileGetDTO userProfileGetDTO = DTOMapper.INSTANCE.convertEntityToUserProfileGetDTO(user);
@@ -96,6 +105,9 @@ public class DTOMapperTest {
 		assertEquals(user.getUsername(), userProfileGetDTO.getUsername());
 		assertEquals(user.getBio(), userProfileGetDTO.getBio());
 		assertEquals(user.getMascotId(), userProfileGetDTO.getMascot_id());
+		assertEquals(user.getRoundsPlayed(), userProfileGetDTO.getRounds_played());
+		assertEquals(user.getAvgDistance(), userProfileGetDTO.getAvg_distance());
+		assertEquals(user.getAvgScore(), userProfileGetDTO.getAvg_score());
 		assertEquals(user.getCreationDate(), userProfileGetDTO.getCreationDate());
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -51,6 +51,7 @@ public class DTOMapperTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
 		user.setToken("1");
+		user.setMascotId(3);
 
 		// MAP -> Create UserGetDTO
 		UserGetDTO userGetDTO = DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
@@ -59,6 +60,7 @@ public class DTOMapperTest {
 		assertEquals(user.getId(), userGetDTO.getId());
 		assertEquals(user.getUsername(), userGetDTO.getUsername());
 		assertEquals(user.getBio(), userGetDTO.getBio());
+		assertEquals(user.getMascotId(), userGetDTO.getMascot_id());
 	}
 
 	@Test
@@ -68,12 +70,14 @@ public class DTOMapperTest {
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
 		user.setToken("token-123");
+		user.setMascotId(2);
 
 		UserRegisterResponseDTO registerResponseDTO = DTOMapper.INSTANCE.convertEntityToUserRegisterResponseDTO(user);
 
 		assertEquals(user.getId(), registerResponseDTO.getId());
 		assertEquals(user.getUsername(), registerResponseDTO.getUsername());
 		assertEquals(user.getBio(), registerResponseDTO.getBio());
+		assertEquals(user.getMascotId(), registerResponseDTO.getMascot_id());
 		assertEquals(user.getToken(), registerResponseDTO.getToken());
 	}
 
@@ -83,6 +87,7 @@ public class DTOMapperTest {
 		user.setId(1L);
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
+		user.setMascotId(4);
 		user.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 
 		UserProfileGetDTO userProfileGetDTO = DTOMapper.INSTANCE.convertEntityToUserProfileGetDTO(user);
@@ -90,6 +95,7 @@ public class DTOMapperTest {
 		assertEquals(user.getId(), userProfileGetDTO.getId());
 		assertEquals(user.getUsername(), userProfileGetDTO.getUsername());
 		assertEquals(user.getBio(), userProfileGetDTO.getBio());
+		assertEquals(user.getMascotId(), userProfileGetDTO.getMascot_id());
 		assertEquals(user.getCreationDate(), userProfileGetDTO.getCreationDate());
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Game_data;
 import ch.uzh.ifi.hase.soprafs26.entity.Session;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
@@ -51,7 +50,6 @@ public class DTOMapperTest {
 		user.setId(1L);
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
-		user.setStatus(UserStatus.OFFLINE);
 		user.setToken("1");
 
 		// MAP -> Create UserGetDTO
@@ -61,7 +59,6 @@ public class DTOMapperTest {
 		assertEquals(user.getId(), userGetDTO.getId());
 		assertEquals(user.getUsername(), userGetDTO.getUsername());
 		assertEquals(user.getBio(), userGetDTO.getBio());
-		assertEquals(user.getStatus(), userGetDTO.getStatus());
 	}
 
 	@Test
@@ -70,7 +67,6 @@ public class DTOMapperTest {
 		user.setId(1L);
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
-		user.setStatus(UserStatus.ONLINE);
 		user.setToken("token-123");
 
 		UserRegisterResponseDTO registerResponseDTO = DTOMapper.INSTANCE.convertEntityToUserRegisterResponseDTO(user);
@@ -78,7 +74,6 @@ public class DTOMapperTest {
 		assertEquals(user.getId(), registerResponseDTO.getId());
 		assertEquals(user.getUsername(), registerResponseDTO.getUsername());
 		assertEquals(user.getBio(), registerResponseDTO.getBio());
-		assertEquals(user.getStatus(), registerResponseDTO.getStatus());
 		assertEquals(user.getToken(), registerResponseDTO.getToken());
 	}
 
@@ -88,7 +83,6 @@ public class DTOMapperTest {
 		user.setId(1L);
 		user.setUsername("firstname@lastname");
 		user.setBio("Hello from bio");
-		user.setStatus(UserStatus.ONLINE);
 		user.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 
 		UserProfileGetDTO userProfileGetDTO = DTOMapper.INSTANCE.convertEntityToUserProfileGetDTO(user);
@@ -96,7 +90,6 @@ public class DTOMapperTest {
 		assertEquals(user.getId(), userProfileGetDTO.getId());
 		assertEquals(user.getUsername(), userProfileGetDTO.getUsername());
 		assertEquals(user.getBio(), userProfileGetDTO.getBio());
-		assertEquals(user.getStatus(), userProfileGetDTO.getStatus());
 		assertEquals(user.getCreationDate(), userProfileGetDTO.getCreationDate());
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 
@@ -60,7 +59,6 @@ public class UserServiceIntegrationTest {
 		assertNotNull(createdUser.getPasswordHash());
 		assertTrue(BCrypt.checkpw("password123", createdUser.getPasswordHash()));
 		assertNotNull(createdUser.getToken());
-		assertEquals(UserStatus.ONLINE, createdUser.getStatus());
 		assertNotNull(createdUser.getCreationDate());
 	}
 
@@ -79,7 +77,6 @@ public class UserServiceIntegrationTest {
 		assertEquals(createdUser.getId(), foundUser.getId());
 		assertEquals(createdUser.getUsername(), foundUser.getUsername());
 		assertEquals(createdUser.getBio(), foundUser.getBio());
-		assertEquals(createdUser.getStatus(), foundUser.getStatus());
 		assertEquals(createdUser.getCreationDate(), foundUser.getCreationDate());
 	}
 
@@ -112,7 +109,6 @@ public class UserServiceIntegrationTest {
 
 		// then
 		assertEquals("testUsername", loggedInUser.getUsername());
-		assertEquals(UserStatus.ONLINE, loggedInUser.getStatus());
 		assertNotNull(loggedInUser.getToken());
 	}
 
@@ -130,7 +126,6 @@ public class UserServiceIntegrationTest {
 
 		// then
 		User updatedUser = userRepository.findById(createdUser.getId()).orElseThrow();
-		assertEquals(UserStatus.OFFLINE, updatedUser.getStatus());
 		assertNotEquals(oldToken, updatedUser.getToken());
 		assertNull(userRepository.findByToken(oldToken));
 	}
@@ -149,7 +144,6 @@ public class UserServiceIntegrationTest {
 
 		// then
 		User updatedUser = userRepository.findById(createdUser.getId()).orElseThrow();
-		assertEquals(UserStatus.OFFLINE, updatedUser.getStatus());
 		assertNotEquals(oldToken, updatedUser.getToken());
 		assertTrue(BCrypt.checkpw("newPassword123", updatedUser.getPasswordHash()));
 	}
@@ -168,7 +162,6 @@ public class UserServiceIntegrationTest {
 		// then
 		User updatedUser = userRepository.findById(createdUser.getId()).orElseThrow();
 		assertEquals("Updated bio", updatedUser.getBio());
-		assertEquals(UserStatus.ONLINE, updatedUser.getStatus());
 	}
 
 	@Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -59,6 +59,7 @@ public class UserServiceIntegrationTest {
 		assertNotNull(createdUser.getPasswordHash());
 		assertTrue(BCrypt.checkpw("password123", createdUser.getPasswordHash()));
 		assertNotNull(createdUser.getToken());
+		assertEquals(1, createdUser.getMascotId());
 		assertNotNull(createdUser.getCreationDate());
 	}
 
@@ -77,6 +78,7 @@ public class UserServiceIntegrationTest {
 		assertEquals(createdUser.getId(), foundUser.getId());
 		assertEquals(createdUser.getUsername(), foundUser.getUsername());
 		assertEquals(createdUser.getBio(), foundUser.getBio());
+		assertEquals(createdUser.getMascotId(), foundUser.getMascotId());
 		assertEquals(createdUser.getCreationDate(), foundUser.getCreationDate());
 	}
 
@@ -140,7 +142,7 @@ public class UserServiceIntegrationTest {
 		String oldToken = createdUser.getToken();
 
 		// when
-		userService.updateUser(createdUser.getId(), oldToken, null, "newPassword123");
+		userService.updateUser(createdUser.getId(), oldToken, null, "newPassword123", null);
 
 		// then
 		User updatedUser = userRepository.findById(createdUser.getId()).orElseThrow();
@@ -157,11 +159,37 @@ public class UserServiceIntegrationTest {
 		User createdUser = userService.createUser(testUser, "oldPassword123");
 
 		// when
-		userService.updateUser(createdUser.getId(), createdUser.getToken(), "  Updated bio  ", null);
+		userService.updateUser(createdUser.getId(), createdUser.getToken(), "  Updated bio  ", null, null);
 
 		// then
 		User updatedUser = userRepository.findById(createdUser.getId()).orElseThrow();
 		assertEquals("Updated bio", updatedUser.getBio());
+	}
+
+	@Test
+	public void updateUser_mascotOnly_success() {
+		User testUser = new User();
+		testUser.setUsername("testUsername");
+		testUser.setBio("Short bio");
+		User createdUser = userService.createUser(testUser, "oldPassword123");
+
+		userService.updateUser(createdUser.getId(), createdUser.getToken(), null, null, 7);
+
+		User updatedUser = userRepository.findById(createdUser.getId()).orElseThrow();
+		assertEquals(7, updatedUser.getMascotId());
+	}
+
+	@Test
+	public void updateUser_invalidMascot_throwsException() {
+		User testUser = new User();
+		testUser.setUsername("testUsername");
+		testUser.setBio("Short bio");
+		User createdUser = userService.createUser(testUser, "oldPassword123");
+
+		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+				() -> userService.updateUser(createdUser.getId(), createdUser.getToken(), null, null, 0));
+
+		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
 	}
 
 	@Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.web.server.ResponseStatusException;
 
-import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 
@@ -43,7 +42,6 @@ public class UserServiceTest {
 		testUser.setUsername("testUsername");
 		testUser.setBio("Short bio");
 		testUser.setToken("valid-token");
-		testUser.setStatus(UserStatus.OFFLINE);
 		testUser.setCreationDate(Instant.parse("2026-02-25T14:35:00Z"));
 
 		// when -> any object being saved in the userRepository returns the dummy
@@ -102,7 +100,6 @@ public class UserServiceTest {
 		assertNotNull(createdUser.getPasswordHash());
 		assertTrue(BCrypt.checkpw(rawPassword, createdUser.getPasswordHash()));
 		assertNotNull(createdUser.getToken());
-		assertEquals(UserStatus.ONLINE, createdUser.getStatus());
 	}
 
 	@Test
@@ -175,9 +172,7 @@ public class UserServiceTest {
 		User loggedInUser = userService.loginUser("testUsername", rawPassword);
 
 		// then
-		Mockito.verify(userRepository).save(testUser);
-		Mockito.verify(userRepository).flush();
-		assertEquals(UserStatus.ONLINE, loggedInUser.getStatus());
+		assertEquals(testUser, loggedInUser);
 	}
 
 	@Test
@@ -203,7 +198,6 @@ public class UserServiceTest {
 	public void logoutUser_validToken_success() {
 		// given
 		String oldToken = "valid-token";
-		testUser.setStatus(UserStatus.ONLINE);
 		testUser.setToken(oldToken);
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
 
@@ -213,7 +207,6 @@ public class UserServiceTest {
 		// then
 		Mockito.verify(userRepository).save(testUser);
 		Mockito.verify(userRepository).flush();
-		assertEquals(UserStatus.OFFLINE, testUser.getStatus());
 		assertNotEquals(oldToken, testUser.getToken());
 	}
 
@@ -238,7 +231,6 @@ public class UserServiceTest {
 		// given
 		String oldToken = "valid-token";
 		String oldPasswordHash = BCrypt.hashpw("oldPassword123", BCrypt.gensalt());
-		testUser.setStatus(UserStatus.ONLINE);
 		testUser.setToken(oldToken);
 		testUser.setPasswordHash(oldPasswordHash);
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
@@ -249,7 +241,6 @@ public class UserServiceTest {
 
 		// then
 		assertEquals("Updated bio", testUser.getBio());
-		assertEquals(UserStatus.ONLINE, testUser.getStatus());
 		assertEquals(oldToken, testUser.getToken());
 		assertEquals(oldPasswordHash, testUser.getPasswordHash());
 	}
@@ -258,7 +249,6 @@ public class UserServiceTest {
 	public void updateUser_passwordOnly_success() {
 		// given
 		String oldToken = "valid-token";
-		testUser.setStatus(UserStatus.ONLINE);
 		testUser.setToken(oldToken);
 		testUser.setPasswordHash(BCrypt.hashpw("oldPassword123", BCrypt.gensalt()));
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
@@ -268,7 +258,6 @@ public class UserServiceTest {
 		userService.updateUser(1L, oldToken, null, "newPassword123");
 
 		// then
-		assertEquals(UserStatus.OFFLINE, testUser.getStatus());
 		assertNotEquals(oldToken, testUser.getToken());
 		assertTrue(BCrypt.checkpw("newPassword123", testUser.getPasswordHash()));
 	}
@@ -276,7 +265,6 @@ public class UserServiceTest {
 	@Test
 	public void updateUser_passwordEmpty(){
 		String oldToken = "valid-token";
-		testUser.setStatus(UserStatus.ONLINE);
 		testUser.setToken(oldToken);
 		testUser.setPasswordHash(BCrypt.hashpw("oldPassword123", BCrypt.gensalt()));
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
@@ -291,7 +279,6 @@ public class UserServiceTest {
 	@Test
 	public void updateUser_passwordTooShort(){
 		String oldToken = "valid-token";
-		testUser.setStatus(UserStatus.ONLINE);
 		testUser.setToken(oldToken);
 		testUser.setPasswordHash(BCrypt.hashpw("oldPassword123", BCrypt.gensalt()));
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -100,6 +100,7 @@ public class UserServiceTest {
 		assertNotNull(createdUser.getPasswordHash());
 		assertTrue(BCrypt.checkpw(rawPassword, createdUser.getPasswordHash()));
 		assertNotNull(createdUser.getToken());
+		assertEquals(1, createdUser.getMascotId());
 	}
 
 	@Test
@@ -159,6 +160,16 @@ public class UserServiceTest {
 		User createdUser = userService.createUser(testUser, "password123");
 
 		assertEquals("", createdUser.getBio());
+	}
+
+	@Test
+	public void createUser_invalidMascot_throwsException() {
+		testUser.setMascotId(0);
+
+		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+				() -> userService.createUser(testUser, "password123"));
+
+		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
 	}
 
 	@Test
@@ -237,7 +248,7 @@ public class UserServiceTest {
 		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
 		// when
-		userService.updateUser(1L, oldToken, "  Updated bio  ", null);
+			userService.updateUser(1L, oldToken, "  Updated bio  ", null, null);
 
 		// then
 		assertEquals("Updated bio", testUser.getBio());
@@ -255,11 +266,67 @@ public class UserServiceTest {
 		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
 		// when
-		userService.updateUser(1L, oldToken, null, "newPassword123");
+			userService.updateUser(1L, oldToken, null, "newPassword123", null);
 
 		// then
 		assertNotEquals(oldToken, testUser.getToken());
 		assertTrue(BCrypt.checkpw("newPassword123", testUser.getPasswordHash()));
+	}
+
+	@Test
+	public void updateUser_mascotOnly_success() {
+		String oldToken = "valid-token";
+		testUser.setToken(oldToken);
+		testUser.setMascotId(1);
+		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		userService.updateUser(1L, oldToken, null, null, 7);
+
+		assertEquals(7, testUser.getMascotId());
+		assertEquals(oldToken, testUser.getToken());
+		Mockito.verify(userRepository).save(testUser);
+		Mockito.verify(userRepository).flush();
+	}
+
+	@Test
+	public void updateUser_bioAndMascot_success() {
+		String oldToken = "valid-token";
+		testUser.setToken(oldToken);
+		testUser.setMascotId(1);
+		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		userService.updateUser(1L, oldToken, "  Updated bio  ", null, 4);
+
+		assertEquals("Updated bio", testUser.getBio());
+		assertEquals(4, testUser.getMascotId());
+	}
+
+	@Test
+	public void updateUser_zeroMascot_throwsBadRequest() {
+		String oldToken = "valid-token";
+		testUser.setToken(oldToken);
+		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+				() -> userService.updateUser(1L, oldToken, null, null, 0));
+
+		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+	}
+
+	@Test
+	public void updateUser_negativeMascot_throwsBadRequest() {
+		String oldToken = "valid-token";
+		testUser.setToken(oldToken);
+		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+				() -> userService.updateUser(1L, oldToken, null, null, -1));
+
+		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
 	}
 
 	@Test
@@ -270,8 +337,8 @@ public class UserServiceTest {
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
 		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
-		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
-			() -> userService.updateUser(1L, oldToken, null, ""));
+			ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+				() -> userService.updateUser(1L, oldToken, null, "", null));
 
 		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
 	}
@@ -284,8 +351,8 @@ public class UserServiceTest {
 		Mockito.when(userRepository.findByToken(oldToken)).thenReturn(testUser);
 		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
-		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
-			() -> userService.updateUser(1L, oldToken, null, "short"));
+			ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+				() -> userService.updateUser(1L, oldToken, null, "short", null));
 
 		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
 	}
@@ -295,8 +362,8 @@ public class UserServiceTest {
 		Mockito.when(userRepository.findByToken("valid-token")).thenReturn(testUser);
 		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
 
-		ResponseStatusException exception = assertThrows(ResponseStatusException.class,
-				() -> userService.updateUser(1L, "valid-token", null, null));
+			ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+					() -> userService.updateUser(1L, "valid-token", null, null, null));
 
 		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
 	}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -384,6 +384,47 @@ public class UserServiceTest {
 	}
 
 	@Test
+	public void recordPlayedRound_firstRound_setsStats() {
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		userService.recordPlayedRound(1L, 1000.0, 50);
+
+		assertEquals(1, testUser.getRoundsPlayed());
+		assertEquals(1000.0, testUser.getAvgDistance(), 1e-9);
+		assertEquals(50.0, testUser.getAvgScore(), 1e-9);
+		Mockito.verify(userRepository).save(testUser);
+		Mockito.verify(userRepository).flush();
+	}
+
+	@Test
+	public void recordPlayedRound_multipleRounds_updatesAverages() {
+		testUser.setRoundsPlayed(2);
+		testUser.setAvgDistance(1000.0);
+		testUser.setAvgScore(75.0);
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		userService.recordPlayedRound(1L, 4000.0, 0);
+
+		assertEquals(3, testUser.getRoundsPlayed());
+		assertEquals(2000.0, testUser.getAvgDistance(), 1e-9);
+		assertEquals(50.0, testUser.getAvgScore(), 1e-9);
+	}
+
+	@Test
+	public void recordPlayedRound_noGuess_usesMaximumDistanceAndZeroScore() {
+		testUser.setRoundsPlayed(1);
+		testUser.setAvgDistance(1000.0);
+		testUser.setAvgScore(100.0);
+		Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+
+		userService.recordPlayedRound(1L, -1.0, 0);
+
+		assertEquals(2, testUser.getRoundsPlayed());
+		assertEquals(10500.0, testUser.getAvgDistance(), 1e-9);
+		assertEquals(50.0, testUser.getAvgScore(), 1e-9);
+	}
+
+	@Test
 	public void getAuthenticatedUser_validToken_success() {
 		// given
 		Mockito.when(userRepository.findByToken("valid-token")).thenReturn(testUser);


### PR DESCRIPTION
@plaiimade 

Implements https://github.com/bergwald/sopra-fs26-group-13-server/issues/109.

Changes made to the backend API:

`GET /users`

- Response items no longer include status.
- Response items now include mascot_id, rounds_played, avg_distance, and avg_score.

`GET /users/{userId}`

- No longer requires Authorization.
- Response no longer includes status.
- Response now includes mascot_id, rounds_played, avg_distance, and avg_score.
- creationDate remains included.

`POST /users`

- Request body unchanged.
- New users get default mascot_id = 1.
- Response no longer includes status.
- Response now includes mascot_id.

`POST /login`

- Response no longer includes status.
- Response now includes mascot_id.
- Login no longer changes an online/offline status field.

`POST /logout`

- Logout no longer changes an online/offline status field; it only invalidates/rotates the token.

`PUT /users/{userId}`

- Request body now supports optional mascot_id.
- At least one of bio, newPassword, or mascot_id must be provided.
- mascot_id must be a positive integer.
- Password changes no longer set user status offline, since status was removed.

`PUT /submit_guess`

- Side effect added: every accepted submitted guess updates the user’s rounds_played, avg_distance, and avg_score.
- A no-guess submission with latitude/longitude -1.0 counts as score 0 and distance 20000.0 km for user averages.