### PR TITLE
Fix the auto-timeout bug by making session timestamps unambiguous on the API boundary

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GameController.java
@@ -7,6 +7,7 @@ import org.springframework.web.server.ResponseStatusException;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GameDataGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGuessPutDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserAnswerPutDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.ApiDateTimeFormatter;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.service.GameService;
 import ch.uzh.ifi.hase.soprafs26.service.GuessEvaluationService;
@@ -54,7 +55,7 @@ public class GameController {
 		Game_data output = gameService.getSessionRoundDataForUser(userId, sessionId, roundNumber);
 		Session session = sessionService.getSessionWithId(sessionId);
 		GameDataGetDTO gameData = DTOMapper.INSTANCE.convertEntityToGameDataGetDTO(output);
-		gameData.setRoundStartedDateTime(session.getRoundStartedDateTime());
+		gameData.setRoundStartedDateTime(ApiDateTimeFormatter.toUtcIsoString(session.getRoundStartedDateTime()));
 		return gameData;
 	}
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SessionController.java
@@ -15,6 +15,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionPutDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SessionUserDetailsGetDTO;
 
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.ApiDateTimeFormatter;
 import ch.uzh.ifi.hase.soprafs26.service.SessionService;
 
 import java.util.List;
@@ -79,10 +80,12 @@ public class SessionController {
 			sessionUserDetail.setSessionId(su.getSession().getIdAsString());
 			sessionUserDetail.setUsername(su.getUser().getUsername());
 			sessionUserDetail.setRoundNumber(su.getSession().getRoundNumber());
-			sessionUserDetail.setSessionExpiryDateTime(su.getSession().getSessionExpiryDateTime());
+			sessionUserDetail.setSessionExpiryDateTime(
+					ApiDateTimeFormatter.toUtcIsoString(su.getSession().getSessionExpiryDateTime()));
 			sessionUserDetail.setScore(su.getScore());
 			sessionUserDetail.setUserRole(su.getUserRole());
-			sessionUserDetail.setRoundStartedDateTime(su.getSession().getRoundStartedDateTime());
+			sessionUserDetail.setRoundStartedDateTime(
+					ApiDateTimeFormatter.toUtcIsoString(su.getSession().getRoundStartedDateTime()));
 			sessionUserDetail.setGuessLatitude(su.getGuessLatitude());
 			sessionUserDetail.setGuessLongitude(su.getGuessLongitude());
 			sessionUserDetail.setGuessSubmitted(su.getGuessSubmitted());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameDataGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GameDataGetDTO.java
@@ -1,13 +1,11 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import java.time.LocalDateTime;
-
 public class GameDataGetDTO {
 
 	private String imageUrl;
 	private int roundNumber;
 	private String sessionId;
-	private LocalDateTime roundStartedDateTime;
+	private String roundStartedDateTime;
 
 	public String getImageUrl() {
 		return imageUrl;
@@ -33,11 +31,11 @@ public class GameDataGetDTO {
 		this.sessionId = sessionId;
 	}
 
-	public LocalDateTime getRoundStartedDateTime() {
+	public String getRoundStartedDateTime() {
 		return roundStartedDateTime;
 	}
 
-	public void setRoundStartedDateTime(LocalDateTime roundStartedDateTime) {
+	public void setRoundStartedDateTime(String roundStartedDateTime) {
 		this.roundStartedDateTime = roundStartedDateTime;
 	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionGetDTO.java
@@ -1,11 +1,9 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import java.time.LocalDateTime;
-
 public class SessionGetDTO {
 
     private String id;
-    private LocalDateTime sessionExpiryDateTime;
+    private String sessionExpiryDateTime;
     private Integer roundNumber;
 
     public String getId() {
@@ -16,11 +14,11 @@ public class SessionGetDTO {
         this.id = id;
     }
 
-    public LocalDateTime getSessionExpiryDateTime() {
+    public String getSessionExpiryDateTime() {
         return sessionExpiryDateTime;
     }
 
-    public void setSessionExpiryDateTime(LocalDateTime sessionExpiryDateTime) {
+    public void setSessionExpiryDateTime(String sessionExpiryDateTime) {
         this.sessionExpiryDateTime = sessionExpiryDateTime;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionUserDetailsGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SessionUserDetailsGetDTO.java
@@ -1,7 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import java.time.LocalDateTime;
-
 import ch.uzh.ifi.hase.soprafs26.constant.UserSessionRole;
 
 public class SessionUserDetailsGetDTO {
@@ -9,11 +7,11 @@ public class SessionUserDetailsGetDTO {
     private Long id;
     private String sessionId;
     private String username;
-    private LocalDateTime sessionExpiryDateTime;
+    private String sessionExpiryDateTime;
     private Integer roundNumber;
     private Long score;
     private UserSessionRole userRole;
-    private LocalDateTime roundStartedDateTime;
+    private String roundStartedDateTime;
     private double guessLatitude;
     private double guessLongitude;
     private boolean guessSubmitted;
@@ -42,11 +40,11 @@ public class SessionUserDetailsGetDTO {
         this.username = username;
     }
 
-    public LocalDateTime getSessionExpiryDateTime() {
+    public String getSessionExpiryDateTime() {
         return sessionExpiryDateTime;
     }
 
-    public void setSessionExpiryDateTime(LocalDateTime sessionExpiryDateTime) {
+    public void setSessionExpiryDateTime(String sessionExpiryDateTime) {
         this.sessionExpiryDateTime = sessionExpiryDateTime;
     }
 
@@ -74,11 +72,11 @@ public class SessionUserDetailsGetDTO {
         this.userRole = userRole;
     }
 
-    public LocalDateTime getRoundStartedDateTime() {
+    public String getRoundStartedDateTime() {
         return roundStartedDateTime;
     }
 
-    public void setRoundStartedDateTime(LocalDateTime roundStartedDateTime) {
+    public void setRoundStartedDateTime(String roundStartedDateTime) {
         this.roundStartedDateTime = roundStartedDateTime;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/ApiDateTimeFormatter.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/ApiDateTimeFormatter.java
@@ -1,0 +1,17 @@
+package ch.uzh.ifi.hase.soprafs26.rest.mapper;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public final class ApiDateTimeFormatter {
+
+    private ApiDateTimeFormatter() {
+    }
+
+    public static String toUtcIsoString(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+        return localDateTime.atZone(ZoneId.systemDefault()).toInstant().toString();
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -82,7 +82,7 @@ public interface DTOMapper {
 	Game_data convertGameGetDTOToEntity(GameGetDTO gameGetDTO);
 
 	@Mapping(source = "id", target = "id")
-	@Mapping(source = "sessionExpiryDateTime", target = "sessionExpiryDateTime")
+	@Mapping(target = "sessionExpiryDateTime", expression = "java(ApiDateTimeFormatter.toUtcIsoString(session.getSessionExpiryDateTime()))")
 	@Mapping(source = "roundNumber", target = "roundNumber")
 	SessionGetDTO convertEntitityToSessionGetDTO(Session session);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GameControllerTest.java
@@ -104,7 +104,10 @@ public class GameControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.imageUrl", is(gameData.getImageUrl())))
                 .andExpect(jsonPath("$.roundNumber", is(gameData.getRoundNumber())))
-                .andExpect(jsonPath("$.sessionId", is(gameData.getSessionId())));
+                .andExpect(jsonPath("$.sessionId", is(gameData.getSessionId())))
+                .andExpect(jsonPath("$.roundStartedDateTime",
+                        is(ch.uzh.ifi.hase.soprafs26.rest.mapper.ApiDateTimeFormatter
+                                .toUtcIsoString(session.getRoundStartedDateTime()))));
     }
 /*
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SessionControllerTest.java
@@ -59,6 +59,7 @@ public class SessionControllerTest {
                 session.setId(testUuid);
                 session.setRoundNumber(0);
                 session.setSessionExpiryDateTime(LocalDateTime.of(2026, 1, 1, 8, 1, 1, 1));
+                session.setRoundStartedDateTime(LocalDateTime.of(2026, 1, 1, 8, 0, 0, 0));
                 return session;
         }
 
@@ -81,6 +82,10 @@ public class SessionControllerTest {
                 return sessionUser;
         }
 
+        private String utcIsoString(LocalDateTime localDateTime) {
+                return ch.uzh.ifi.hase.soprafs26.rest.mapper.ApiDateTimeFormatter.toUtcIsoString(localDateTime);
+        }
+
         @Test
         public void givenSessions_whenGetSession_thenReturnJsonArray() throws Exception {
                 Session session = sampleSession();
@@ -97,7 +102,7 @@ public class SessionControllerTest {
                                 .andExpect(jsonPath("$[0].id", is(session.getId().toString())))
                                 .andExpect(jsonPath("$[0].roundNumber", is(session.getRoundNumber())))
                                 .andExpect(jsonPath("$[0].sessionExpiryDateTime",
-                                                is(session.getSessionExpiryDateTime().toString())));
+                                                is(utcIsoString(session.getSessionExpiryDateTime()))));
         }
 
         @Test
@@ -156,8 +161,11 @@ public class SessionControllerTest {
                                 .andExpect(jsonPath("$[0].roundNumber",
                                                 is(sampleSessionUser.getSession().getRoundNumber())))
                                 .andExpect(jsonPath("$[0].sessionExpiryDateTime",
-                                                is(sampleSessionUser.getSession().getSessionExpiryDateTime()
-                                                                .toString())))
+                                                is(utcIsoString(sampleSessionUser.getSession()
+                                                                .getSessionExpiryDateTime()))))
+                                .andExpect(jsonPath("$[0].roundStartedDateTime",
+                                                is(utcIsoString(sampleSessionUser.getSession()
+                                                                .getRoundStartedDateTime()))))
                                 .andExpect(jsonPath("$[0].score", is(sampleSessionUser.getScore().intValue())))
                                 .andExpect(jsonPath("$[0].userRole", is(sampleSessionUser.getUserRole().toString())));
 
@@ -264,7 +272,7 @@ public class SessionControllerTest {
                                 .andExpect(jsonPath("$.id", is(session.getId().toString())))
                                 .andExpect(jsonPath("$.roundNumber", is(session.getRoundNumber())))
                                 .andExpect(jsonPath("$.sessionExpiryDateTime",
-                                                is(session.getSessionExpiryDateTime().toString())));
+                                                is(utcIsoString(session.getSessionExpiryDateTime()))));
         }
 
         @Test
@@ -326,7 +334,7 @@ public class SessionControllerTest {
                                 .andExpect(jsonPath("$.id", is(session.getId().toString())))
                                 .andExpect(jsonPath("$.roundNumber", is(session.getRoundNumber())))
                                 .andExpect(jsonPath("$.sessionExpiryDateTime",
-                                                is(session.getSessionExpiryDateTime().toString())));
+                                                is(utcIsoString(session.getSessionExpiryDateTime()))));
         }
 
         @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -158,7 +158,8 @@ public class DTOMapperTest {
 
 		assertEquals(session.getIdAsString(), sessionGetDTO.getId());
 		assertEquals(session.getRoundNumber(), sessionGetDTO.getRoundNumber());
-		assertEquals(session.getSessionExpiryDateTime(), sessionGetDTO.getSessionExpiryDateTime());
+		assertEquals(ApiDateTimeFormatter.toUtcIsoString(session.getSessionExpiryDateTime()),
+				sessionGetDTO.getSessionExpiryDateTime());
 	}
 
 	@Test


### PR DESCRIPTION
Final bugfix for https://github.com/bergwald/sopra-fs26-group-13-client/issues/36