### PR TITLE
Create new route GET /auth/validate to validate client-side user authentication credentials

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -72,6 +72,15 @@ public class UserController {
 		return DTOMapper.INSTANCE.convertEntityToUserRegisterResponseDTO(loggedInUser);
 	}
 
+	@GetMapping("/auth/validate")
+	@ResponseStatus(HttpStatus.OK)
+	public UserProfileGetDTO validateAuthenticatedUser(
+			@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+		String token = this.userService.extractBearerToken(authorizationHeader);
+		User authenticatedUser = userService.getAuthenticatedUser(token);
+		return DTOMapper.INSTANCE.convertEntityToUserProfileGetDTO(authenticatedUser);
+	}
+
 	@PostMapping("/logout")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void logoutUser(@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -213,6 +213,55 @@ public class UserControllerTest {
 				.andExpect(status().isUnauthorized());
 	}
 
+	@Test
+	public void validateAuth_validToken_returnAuthenticatedUser() throws Exception {
+		// given
+		User user = sampleUser();
+		when(userService.extractBearerToken("Bearer valid-token")).thenReturn("valid-token");
+		when(userService.getAuthenticatedUser("valid-token")).thenReturn(user);
+
+		// when/then
+		mockMvc.perform(get("/auth/validate")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("Authorization", "Bearer valid-token"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is(1)))
+				.andExpect(jsonPath("$.username", is("testUsername")))
+				.andExpect(jsonPath("$.bio", is("Short bio")))
+				.andExpect(jsonPath("$.mascot_id", is(3)))
+				.andExpect(jsonPath("$.rounds_played", is(4)))
+				.andExpect(jsonPath("$.avg_distance", is(1250.5)))
+				.andExpect(jsonPath("$.score", is(289)));
+
+		verify(userService).extractBearerToken("Bearer valid-token");
+		verify(userService).getAuthenticatedUser("valid-token");
+	}
+
+	@Test
+	public void validateAuth_missingAuthorizationHeader_unauthorized() throws Exception {
+		// given
+		when(userService.extractBearerToken(null))
+				.thenThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The provided token is invalid."));
+
+		// when/then
+		mockMvc.perform(get("/auth/validate").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	public void validateAuth_invalidToken_unauthorized() throws Exception {
+		// given
+		when(userService.extractBearerToken("Bearer invalid-token")).thenReturn("invalid-token");
+		when(userService.getAuthenticatedUser("invalid-token"))
+				.thenThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "The provided token is invalid."));
+
+		// when/then
+		mockMvc.perform(get("/auth/validate")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("Authorization", "Bearer invalid-token"))
+				.andExpect(status().isUnauthorized());
+	}
+
 	/**
 	 * Tests POST /logout and verifies a valid bearer token logs out with 204 No
 	 * Content.


### PR DESCRIPTION
Implements server-side solution for https://github.com/bergwald/sopra-fs26-group-13-client/issues/73